### PR TITLE
Added Full Stack Fest 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Stockholm, **Sweden**
 16-17 September, 2017  
 Ekaterinburg, **Russia**
 
-[**Full Stack Fest 2017**](http://2017.fullstackfest.com/)
+[**Full Stack Fest 2017**](http://2017.fullstackfest.com/)  
 4-8 September, 2017  
 Barcelona, **Spain**
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Stockholm, **Sweden**
 16-17 September, 2017  
 Ekaterinburg, **Russia**
 
+[**Full Stack Fest 2017**](http://2017.fullstackfest.com/)
+4-8 September, 2017  
+Barcelona, **Spain**
+
 [**AngularConnect**](http://angularconnect.com/)  
 7-8 September, 2017  
 London, **England**


### PR DESCRIPTION
Added Full Stack Fest 2017 conference to the list. It has a frontend track of two days, with topics around UX & the browser.