### PR TITLE
Adds "Frontend NE: the conference" to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Moscow, **Russian Federation
 Fall 2017  
 Wroclaw, **Poland**
 
-[**Frontend NE: The Conference**](https://2018.frontendne.co.uk)
-April 5th 2018
+[**Frontend NE: The Conference**](https://2018.frontendne.co.uk)  
+April 5th 2018  
 Newcastle-Upon-Tyne, **England**
 
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Moscow, **Russian Federation
 Fall 2017  
 Wroclaw, **Poland**
 
+[**Frontend NE: The Conference**](https://2018.frontendne.co.uk)
+April 5th 2018
+Newcastle-Upon-Tyne, **England**
 
 ## Middle East
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Wroclaw, **Poland**
 April 5th 2018
 Newcastle-Upon-Tyne, **England**
 
+
 ## Middle East
 
 [**ReactNext**](http://react-next.com/)  


### PR DESCRIPTION
It's a little ways in the future, but it's better to be prepared.

All current info is available here (https://2018.frontendne.co.uk)
Speaker announcement and tickets will be going out on August 2nd