### PR TITLE
Update AngularCamp website

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Darmstadt, **Germany**
 7 September 2018  
 Tallinn, **Estonia**
 
-[**AngularCamp 2018**](https://angularcamp.org/)  
+[**AngularCamp 2018 - JS Conference & Workshops **](https://angularcamp.tech/)  
 18-20 July 2018  
 Barcelona, **Spain**
 


### PR DESCRIPTION
AngularCamp is now a JavaScript Conference, just added some context on the title as can create confusion by just the name. Thank you for making this, everyone is welcome to join us!