### PR TITLE
add typeof conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Munich, **Germany**
 22 March 2019  
 Manchester, **England**
 
+[**Typeof**](https://typeofconf.com/)  
+27-29 March 2019  
+Porto, **Portugal**
+
 [**Frontend NE: The Conference**](https://2019.frontendne.co.uk)  
 3 April 2019  
 Newcastle-Upon-Tyne, **England**


### PR DESCRIPTION
typeof is a professional front end and web technologies conference.

The inaugural edition is taking place in Alfândega do Porto, with workshops on the 27th and a single track of talks conference on the 28th and 29th of March.