### PR TITLE
add WebExpo 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Freiburg, **Germany**
 19-20 September 2019  
 London, **United Kingdom**
 
-**WebExpo 2019**](https://www.webexpo.net/prague2019)  
+[**WebExpo 2019**](https://www.webexpo.net/prague2019)  
 20-22 September 2019  
 Prague, **Czechia**
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Freiburg, **Germany**
 19-20 September 2019  
 London, **United Kingdom**
 
+**WebExpo 2019**](https://www.webexpo.net/prague2019)  
+20-22 September 2019  
+Prague, **Czechia**
+
 [**Codemotion // Madrid**](https://events.codemotion.com/conferences/madrid/2019/)  
 24-25 September 2019  
 Madrid, **Spain** 


### PR DESCRIPTION
This PR adds WebExpo 2019 in Prague to the list.