### PR TITLE
Update SmashingConf SF dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ Portland, OR, **USA**
 7–8 April 2020  
 NYC, NY, **USA**
 
-[**SmashingConf San Francisco 2020**](https://smashingconf.com/sf-2020/)  
-21–22 April 2020  
-San Francisco, CA, **USA**
-
 [**HalfStack Charlotte**](https://www.halfstackconf.com/charlotte/)  
 24 April 2020  
 Charlotte, NC, **USA**
@@ -187,6 +183,10 @@ San Francisco, CA, **USA**
 [**SmashingConf New York 2020**](https://smashingconf.com/ny-2020/)  
 20–21 October 2020  
 NYC, NY, **USA**
+
+[**SmashingConf San Francisco 2020**](https://smashingconf.com/sf-2020/)  
+10-11 November 2020  
+San Francisco, CA, **USA**
 
 ## South America
 


### PR DESCRIPTION
They changed dates due to COVID-19:

![image](https://user-images.githubusercontent.com/1900909/76763108-dd94d600-6768-11ea-91fa-a15b9bdfa373.png)

See this link: https://smashingconf.com/sf-2020/postponed