### PR TITLE
Add MadVue 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ London, **United Kingdom** or **Online**
 28-30 May 2025  
 Kraków, **Poland** or **Online**
 
+[**MadVue 2025 – Vue.js Conf**](https://madvue.es/?utm_source=frontendfront)  
+29 May 2025  
+Madrid, **Spain**
+
 [**JSHeroes**](https://jsheroes.io/)  
 29-30 May 2025  
 Cluj-Napoca, **Romania**


### PR DESCRIPTION
Added MadVue 2025, the Vue.js event in Madrid happening on May 29th